### PR TITLE
Fix Firefox inner-site-wrapper glitch

### DIFF
--- a/styles/css/cover.css
+++ b/styles/css/cover.css
@@ -47,6 +47,7 @@ body {
   display: table-cell;
   vertical-align: top;
   padding-top: 1em;
+  height: 100%; /* For Firefox */
 }
 .cover-container {
   margin-right: auto;


### PR DESCRIPTION
In Firefox inner-site-wrapper div had 0 height. Changed cover.css to give .inner-site-wrapper height: 100%
